### PR TITLE
Pass ExtensionContext as parameter to customizer, updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ru.lanwen.wiremock</groupId>
     <artifactId>wiremock-junit5</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/lanwen/wiremock-junit5</url>
@@ -37,13 +37,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <wiremock.version>2.5.1</wiremock.version>
-        <feign.version>9.5.0</feign.version>
-        <lombok.version>1.16.16</lombok.version>
-        <logback.version>1.1.11</logback.version>
-        <jacoco.version>0.7.7.201606060606</jacoco.version>
-        <junit.jupiter.version>5.0.0</junit.jupiter.version>
-        <junit.platform.version>1.0.0</junit.platform.version>
+        <wiremock.version>2.16.0</wiremock.version>
+        <feign.version>9.6.0</feign.version>
+        <lombok.version>1.16.20</lombok.version>
+        <logback.version>1.2.3</logback.version>
+        <jacoco.version>0.8.1</jacoco.version>
+        <junit.jupiter.version>5.1.0</junit.jupiter.version>
+        <junit.platform.version>1.1.0</junit.platform.version>
     </properties>
 
     <dependencyManagement>
@@ -157,7 +157,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -166,7 +166,7 @@
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19</version>
+                <version>2.21.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>
@@ -243,7 +243,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -257,7 +257,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -269,7 +269,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -283,7 +283,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizer.java
+++ b/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizer.java
@@ -1,6 +1,7 @@
 package ru.lanwen.wiremock.config;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
 
@@ -12,11 +13,11 @@ import ru.lanwen.wiremock.ext.WiremockResolver;
  */
 public interface WiremockCustomizer {
 
-    void customize(final WireMockServer server);
+    void customize(WireMockServer server, ExtensionContext context);
 
     class NoopWiremockCustomizer implements WiremockCustomizer {
         @Override
-        public void customize(final WireMockServer server) {
+        public void customize(final WireMockServer server, final ExtensionContext context) {
             // noop
         }
     }

--- a/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
+++ b/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
@@ -69,7 +69,7 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback {
         server.start();
 
         try {
-            mockedServer.customizer().newInstance().customize(server);
+            mockedServer.customizer().newInstance().customize(server, context);
         } catch (ReflectiveOperationException e) {
             throw new ParameterResolutionException(
                     format("Can't customize server with given customizer %s", mockedServer.customizer()),

--- a/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static ru.lanwen.wiremock.testlib.TicketEndpoint.X_TEST_METHOD_NAME_HEADER;
 import static ru.lanwen.wiremock.testlib.TicketEndpoint.X_TICKET_ID_HEADER;
 
 /**
@@ -32,6 +33,10 @@ class WiremockResolverTest {
         TicketApi api = TicketApi.connect(uri);
 
         Response response = api.create(new Eticket());
+        Collection<String> testMethodNames = response.headers().get(X_TEST_METHOD_NAME_HEADER);
+        assertThat("testMethodNames", testMethodNames, hasSize(1));
+        assertThat("shouldCreateTicket", is(testMethodNames.iterator().next()));
+
         Collection<String> ids = response.headers().get(X_TICKET_ID_HEADER);
 
         assertThat("ids", ids, hasSize(1));

--- a/src/test/java/ru/lanwen/wiremock/testlib/TicketEndpoint.java
+++ b/src/test/java/ru/lanwen/wiremock/testlib/TicketEndpoint.java
@@ -1,6 +1,7 @@
 package ru.lanwen.wiremock.testlib;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import ru.lanwen.wiremock.config.WiremockCustomizer;
 
 import java.util.UUID;
@@ -17,10 +18,12 @@ import static java.lang.String.format;
 public class TicketEndpoint implements WiremockCustomizer {
 
     public static final String X_TICKET_ID_HEADER = "X-Ticket-ID";
+    public static final String X_TEST_METHOD_NAME_HEADER = "X-TestMethodName";
 
     @Override
-    public void customize(WireMockServer server) {
+    public void customize(WireMockServer server, ExtensionContext context) {
         String uuid = UUID.randomUUID().toString();
+        String testMethodName = context.getTestMethod().get().getName();
 
         server.stubFor(
                 post(urlPathEqualTo("/ticket"))
@@ -30,6 +33,7 @@ public class TicketEndpoint implements WiremockCustomizer {
                                         "Location",
                                         format("http://localhost:%s/ticket/%s", server.port(), uuid)
                                 )
+                                .withHeader(X_TEST_METHOD_NAME_HEADER, testMethodName)
                                 .withHeader(X_TICKET_ID_HEADER, uuid))
         );
 
@@ -38,6 +42,7 @@ public class TicketEndpoint implements WiremockCustomizer {
                         .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader("Content-Type", "application/json")
+                                .withHeader(X_TEST_METHOD_NAME_HEADER, testMethodName)
                                 .withHeader(X_TICKET_ID_HEADER, uuid)
                                 .withBody(format("{ \"uuid\": \"%s\" }", uuid))
                         )


### PR DESCRIPTION
Hi,

I came across the requirement to implement some dynamic behavior depending on the actual test method while customizing a WireMock server. For this reason, I added JUnit5's ExtensionContext object to the signature of WiremockCustomizer. Because the interface change, I bumped the version to 2.0.0-SNAPSHOT. Furthermore, I upgraded the dependencies to the most recent versions.

Have a nice day!