### PR TITLE
Refactored WiremockCustomizer to take a CustomizationContext as argument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jacoco.version>0.7.7.201606060606</jacoco.version>
         <junit.jupiter.version>5.1.0</junit.jupiter.version>
         <junit.platform.version>1.1.0</junit.platform.version>
-        <mockito.version>2.17.0</mockito.version>
+        <mockito.version>2.18.3</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -104,6 +104,11 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -160,6 +165,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ru.lanwen.wiremock</groupId>
     <artifactId>wiremock-junit5</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/lanwen/wiremock-junit5</url>
@@ -37,13 +37,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <wiremock.version>2.5.1</wiremock.version>
-        <feign.version>9.5.0</feign.version>
-        <lombok.version>1.16.16</lombok.version>
-        <logback.version>1.1.11</logback.version>
+        <wiremock.version>2.16.0</wiremock.version>
+        <feign.version>9.6.0</feign.version>
+        <lombok.version>1.16.20</lombok.version>
+        <logback.version>1.2.3</logback.version>
         <jacoco.version>0.7.7.201606060606</jacoco.version>
-        <junit.jupiter.version>5.0.0</junit.jupiter.version>
-        <junit.platform.version>1.0.0</junit.platform.version>
+        <junit.jupiter.version>5.1.0</junit.jupiter.version>
+        <junit.platform.version>1.1.0</junit.platform.version>
+        <mockito.version>2.17.0</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -98,6 +99,11 @@
                 <version>${logback.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -151,13 +157,19 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -165,8 +177,9 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19</version>
+                <version>2.19.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>
@@ -243,7 +256,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -257,7 +270,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -269,7 +282,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -283,7 +296,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/src/main/java/ru/lanwen/wiremock/config/CustomizationContext.java
+++ b/src/main/java/ru/lanwen/wiremock/config/CustomizationContext.java
@@ -1,0 +1,18 @@
+package ru.lanwen.wiremock.config;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+@Value
+@Builder
+@NonFinal
+public class CustomizationContext {
+    ExtensionContext extensionContext;
+    ParameterContext parameterContext;
+}

--- a/src/main/java/ru/lanwen/wiremock/config/WiremockConfigFactory.java
+++ b/src/main/java/ru/lanwen/wiremock/config/WiremockConfigFactory.java
@@ -4,6 +4,8 @@ import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
 /**
  * You can create custom config to init wiremock server in test.
  *
@@ -26,7 +28,7 @@ public interface WiremockConfigFactory {
 
         @Override
         public WireMockConfiguration create() {
-            return WireMockConfiguration.options().dynamicPort().notifier(new Slf4jNotifier(true));
+            return options().dynamicPort().notifier(new Slf4jNotifier(true));
         }
     }
 }

--- a/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizer.java
+++ b/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizer.java
@@ -12,12 +12,15 @@ import ru.lanwen.wiremock.ext.WiremockResolver;
  */
 public interface WiremockCustomizer {
 
-    void customize(final WireMockServer server);
+    default void customize(WireMockServer server) throws Exception {
+        // noop
+    }
+
+    default void customize(WireMockServer server, CustomizationContext ctx) throws Exception {
+        customize(server);
+    }
 
     class NoopWiremockCustomizer implements WiremockCustomizer {
-        @Override
-        public void customize(final WireMockServer server) {
-            // noop
-        }
+
     }
 }

--- a/src/main/java/ru/lanwen/wiremock/ext/WiremockFactory.java
+++ b/src/main/java/ru/lanwen/wiremock/ext/WiremockFactory.java
@@ -1,0 +1,42 @@
+package ru.lanwen.wiremock.ext;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import ru.lanwen.wiremock.config.CustomizationContext;
+import ru.lanwen.wiremock.config.CustomizationContext.CustomizationContextBuilder;
+import ru.lanwen.wiremock.config.WiremockCustomizer;
+import ru.lanwen.wiremock.ext.WiremockResolver.Wiremock;
+
+import static java.lang.String.format;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+class WiremockFactory {
+
+    public WireMockServer createServer(final Wiremock mockedServer) {
+        try {
+            return new WireMockServer(mockedServer.factory().newInstance().create());
+        } catch (ReflectiveOperationException e) {
+            throw new ParameterResolutionException(
+                    format("Can't create config with given factory %s", mockedServer.factory()),
+                    e
+            );
+        }
+    }
+
+    public CustomizationContextBuilder createContextBuilder() {
+        return CustomizationContext.builder();
+    }
+
+    public WiremockCustomizer createCustomizer(final Wiremock mockedServer) {
+        try {
+            return mockedServer.customizer().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new ParameterResolutionException(
+                    format("Can't customize server with given customizer %s", mockedServer.customizer()),
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
+++ b/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
@@ -77,7 +77,7 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback {
             wiremockFactory.createCustomizer(mockedServer).customize(server, customizationContext);
         } catch (Exception e) {
             throw new ParameterResolutionException(
-                    format("Can't customize server with given customizer %s", mockedServer),
+                    format("Can't customize server with given customizer %s", mockedServer.customizer()),
                     e
             );
         }

--- a/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
+++ b/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import ru.lanwen.wiremock.config.CustomizationContext;
 import ru.lanwen.wiremock.config.WiremockConfigFactory;
 import ru.lanwen.wiremock.config.WiremockCustomizer;
 
@@ -15,9 +16,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.Optional;
 
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static ru.lanwen.wiremock.ext.Validate.validState;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -26,7 +28,16 @@ import static java.lang.String.format;
 public class WiremockResolver implements ParameterResolver, AfterEachCallback {
     static final String WIREMOCK_PORT = "wiremock.port";
 
+    private final WiremockFactory wiremockFactory;
     private WireMockServer server;
+
+    public WiremockResolver() {
+        this(new WiremockFactory());
+    }
+
+    WiremockResolver(final WiremockFactory wiremockFactory) {
+        this.wiremockFactory = wiremockFactory;
+    }
 
     @Override
     public void afterEach(ExtensionContext testExtensionContext) throws Exception {
@@ -46,38 +57,32 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback {
     }
 
     @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context) {
-        Validate.validState(
-                !Optional.ofNullable(server).map(WireMockServer::isRunning).orElse(false),
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        validState(
+                !ofNullable(server).map(WireMockServer::isRunning).orElse(false),
                 "Can't inject more than one server"
         );
 
         Wiremock mockedServer = parameterContext.getParameter().getAnnotation(Wiremock.class);
 
-
-        try {
-            server = new WireMockServer(
-                    mockedServer.factory().newInstance().create()
-            );
-        } catch (ReflectiveOperationException e) {
-            throw new ParameterResolutionException(
-                    format("Can't create config with given factory %s", mockedServer.factory()),
-                    e
-            );
-        }
-
+        server = wiremockFactory.createServer(mockedServer);
         server.start();
 
+        CustomizationContext customizationContext = wiremockFactory.createContextBuilder().
+                parameterContext(parameterContext).
+                extensionContext(extensionContext).
+                build();
+
         try {
-            mockedServer.customizer().newInstance().customize(server);
-        } catch (ReflectiveOperationException e) {
+            wiremockFactory.createCustomizer(mockedServer).customize(server, customizationContext);
+        } catch (Exception e) {
             throw new ParameterResolutionException(
-                    format("Can't customize server with given customizer %s", mockedServer.customizer()),
+                    format("Can't customize server with given customizer %s", mockedServer),
                     e
             );
         }
 
-        ExtensionContext.Store store = context.getStore(Namespace.create(WiremockResolver.class));
+        ExtensionContext.Store store = extensionContext.getStore(Namespace.create(WiremockResolver.class));
         store.put(WIREMOCK_PORT, server.port());
 
         log.info("Started wiremock server on localhost:{}", server.port());

--- a/src/test/java/ru/lanwen/wiremock/config/DefaultWiremockConfigFactoryTest.java
+++ b/src/test/java/ru/lanwen/wiremock/config/DefaultWiremockConfigFactoryTest.java
@@ -1,0 +1,22 @@
+package ru.lanwen.wiremock.config;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.Test;
+import ru.lanwen.wiremock.config.WiremockConfigFactory.DefaultWiremockConfigFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+public class DefaultWiremockConfigFactoryTest {
+    private DefaultWiremockConfigFactory factory = new DefaultWiremockConfigFactory();
+
+    @Test
+    public void create() {
+        WireMockConfiguration config = factory.create();
+        assertEquals(0, config.portNumber());
+        assertEquals(Slf4jNotifier.class, config.notifier().getClass());
+    }
+}

--- a/src/test/java/ru/lanwen/wiremock/config/NoopWiremockCustomizerTest.java
+++ b/src/test/java/ru/lanwen/wiremock/config/NoopWiremockCustomizerTest.java
@@ -1,26 +1,19 @@
 package ru.lanwen.wiremock.config;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import ru.lanwen.wiremock.config.WiremockCustomizer.NoopWiremockCustomizer;
 
-import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * @author SourcePond (Roland Hauser)
  */
-public class WiremockCustomizerTest {
+public class NoopWiremockCustomizerTest {
     private WireMockServer server = mock(WireMockServer.class);
     private CustomizationContext customizable = mock(CustomizationContext.class);
-    private WiremockCustomizer customizer = mock(WiremockCustomizer.class);
-
-    @BeforeEach
-    public void setup() throws Exception {
-        doCallRealMethod().when(customizer).customize(server);
-        doCallRealMethod().when(customizer).customize(server, customizable);
-    }
+    private WiremockCustomizer customizer = new NoopWiremockCustomizer();
 
     @Test
     public void customize() throws Exception {

--- a/src/test/java/ru/lanwen/wiremock/config/WiremockCustomizerTest.java
+++ b/src/test/java/ru/lanwen/wiremock/config/WiremockCustomizerTest.java
@@ -1,0 +1,36 @@
+package ru.lanwen.wiremock.config;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+public class WiremockCustomizerTest {
+    private WireMockServer server = mock(WireMockServer.class);
+    private CustomizationContext customizable = mock(CustomizationContext.class);
+    private WiremockCustomizer customizer = mock(WiremockCustomizer.class);
+
+    @BeforeEach
+    public void setup() throws Exception {
+        doCallRealMethod().when(customizer).customize(server);
+        doCallRealMethod().when(customizer).customize(server, customizable);
+    }
+
+    @Test
+    public void customize() throws Exception {
+        customizer.customize(server);
+        verifyZeroInteractions(server, customizable);
+    }
+
+    @Test
+    public void customizeWithContext() throws Exception {
+        customizer.customize(server, customizable);
+        verifyZeroInteractions(server, customizable);
+    }
+}

--- a/src/test/java/ru/lanwen/wiremock/ext/CustomizationContextTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/CustomizationContextTest.java
@@ -1,0 +1,37 @@
+package ru.lanwen.wiremock.ext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import ru.lanwen.wiremock.config.CustomizationContext;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static ru.lanwen.wiremock.config.CustomizationContext.builder;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+public class CustomizationContextTest {
+    private ExtensionContext extensionContext = mock(ExtensionContext.class);
+    private ParameterContext parameterContext = mock(ParameterContext.class);
+    private CustomizationContext customizationContext = builder().
+            parameterContext(parameterContext).
+            extensionContext(extensionContext).
+            build();
+
+    @Test
+    public void getExtensionContext() {
+        assertSame(extensionContext, customizationContext.getExtensionContext());
+    }
+
+    @Test
+    public void getParameterContext() {
+        assertSame(parameterContext, customizationContext.getParameterContext());
+    }
+
+    @Test
+    public void verifyToString() {
+        System.out.println(customizationContext.toString());
+    }
+}

--- a/src/test/java/ru/lanwen/wiremock/ext/CustomizationContextTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/CustomizationContextTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import ru.lanwen.wiremock.config.CustomizationContext;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static ru.lanwen.wiremock.config.CustomizationContext.builder;
 
@@ -32,6 +33,9 @@ public class CustomizationContextTest {
 
     @Test
     public void verifyToString() {
-        System.out.println(customizationContext.toString());
+        final String toString = customizationContext.toString();
+        assertTrue(toString.contains(CustomizationContext.class.getSimpleName()));
+        assertTrue(toString.contains("extensionContext"));
+        assertTrue(toString.contains("parameterContext"));
     }
 }

--- a/src/test/java/ru/lanwen/wiremock/ext/ValidateTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/ValidateTest.java
@@ -1,0 +1,46 @@
+package ru.lanwen.wiremock.ext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static ru.lanwen.wiremock.ext.Validate.validState;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+public class ValidateTest {
+    private static final String EXPECTED_MESSAGE = "Expected message";
+
+    @Test
+    public void instantiationNotAllowed() {
+        Executable instantiationNotAllowed = () -> {
+            Constructor<Validate> constructor = Validate.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            try {
+                constructor.newInstance();
+            } catch (final InvocationTargetException e) {
+                throw e.getTargetException();
+            }
+        };
+        assertThrows(UnsupportedOperationException.class, instantiationNotAllowed, "Exception expected");
+    }
+
+    @Test
+    public void verifyValidState() {
+        // Should not throw an exception
+        validState(true, EXPECTED_MESSAGE);
+
+        try {
+            validState(false, EXPECTED_MESSAGE);
+            fail("Exception expected");
+        } catch (final IllegalStateException e) {
+            assertEquals(EXPECTED_MESSAGE, e.getMessage());
+        }
+    }
+}

--- a/src/test/java/ru/lanwen/wiremock/ext/ValidateTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/ValidateTest.java
@@ -1,14 +1,11 @@
 package ru.lanwen.wiremock.ext;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static ru.lanwen.wiremock.ext.Validate.validState;
 
 /**
@@ -19,7 +16,7 @@ public class ValidateTest {
 
     @Test
     public void instantiationNotAllowed() {
-        Executable instantiationNotAllowed = () -> {
+        assertThrows(UnsupportedOperationException.class, () -> {
             Constructor<Validate> constructor = Validate.class.getDeclaredConstructor();
             constructor.setAccessible(true);
             try {
@@ -27,20 +24,13 @@ public class ValidateTest {
             } catch (final InvocationTargetException e) {
                 throw e.getTargetException();
             }
-        };
-        assertThrows(UnsupportedOperationException.class, instantiationNotAllowed, "Exception expected");
+        }, "Exception expected");
     }
 
     @Test
     public void verifyValidState() {
         // Should not throw an exception
         validState(true, EXPECTED_MESSAGE);
-
-        try {
-            validState(false, EXPECTED_MESSAGE);
-            fail("Exception expected");
-        } catch (final IllegalStateException e) {
-            assertEquals(EXPECTED_MESSAGE, e.getMessage());
-        }
+        assertThrows(IllegalStateException.class, () -> validState(false, EXPECTED_MESSAGE), EXPECTED_MESSAGE);
     }
 }

--- a/src/test/java/ru/lanwen/wiremock/ext/WiremockFactoryTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/WiremockFactoryTest.java
@@ -79,7 +79,7 @@ public class WiremockFactoryTest {
             factory.createServer(mockedServer);
             fail("Exception expected here");
         } catch (final ParameterResolutionException expected) {
-            assertEquals("Can't createServer config with given factory class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed", expected.getMessage());
+            assertEquals("Can't create config with given factory class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed", expected.getMessage());
         }
     }
 

--- a/src/test/java/ru/lanwen/wiremock/ext/WiremockFactoryTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/WiremockFactoryTest.java
@@ -11,11 +11,10 @@ import ru.lanwen.wiremock.config.WiremockCustomizer;
 import ru.lanwen.wiremock.ext.WiremockResolver.Wiremock;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,13 +73,9 @@ public class WiremockFactoryTest {
     @Test
     public void configFactoryCouldNotBeInstantiated() {
         when(mockedServer.factory()).thenReturn((Class) PrivateClassNotAllowed.class);
-
-        try {
-            factory.createServer(mockedServer);
-            fail("Exception expected here");
-        } catch (final ParameterResolutionException expected) {
-            assertEquals("Can't create config with given factory class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed", expected.getMessage());
-        }
+        assertThrows(ParameterResolutionException.class,
+                () -> factory.createServer(mockedServer),
+                "Can't create config with given factory class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed");
     }
 
     @Test
@@ -104,12 +99,8 @@ public class WiremockFactoryTest {
     @Test
     public void customizerCouldNotBeInstantiated() {
         when(mockedServer.customizer()).thenReturn((Class) PrivateClassNotAllowed.class);
-
-        try {
-            factory.createCustomizer(mockedServer);
-            fail("Exception expected here");
-        } catch (final ParameterResolutionException expected) {
-            assertEquals("Can't customize server with given customizer class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed", expected.getMessage());
-        }
+        assertThrows(ParameterResolutionException.class,
+                () -> factory.createCustomizer(mockedServer),
+                "Can't customize server with given customizer class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed");
     }
 }

--- a/src/test/java/ru/lanwen/wiremock/ext/WiremockFactoryTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/WiremockFactoryTest.java
@@ -1,0 +1,115 @@
+package ru.lanwen.wiremock.ext;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import ru.lanwen.wiremock.config.CustomizationContext.CustomizationContextBuilder;
+import ru.lanwen.wiremock.config.WiremockConfigFactory;
+import ru.lanwen.wiremock.config.WiremockCustomizer;
+import ru.lanwen.wiremock.ext.WiremockResolver.Wiremock;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+public class WiremockFactoryTest {
+
+    public static class StubClass implements WiremockConfigFactory, WiremockCustomizer {
+
+        @Override
+        public WireMockConfiguration create() {
+            return OPTIONS;
+        }
+
+        @Override
+        public void customize(WireMockServer server) {
+            // noop
+        }
+    }
+
+    private static class PrivateClassNotAllowed implements WiremockConfigFactory, WiremockCustomizer {
+
+        @Override
+        public WireMockConfiguration create() {
+            return null;
+        }
+
+        @Override
+        public void customize(WireMockServer server) {
+            // noop
+        }
+    }
+
+    private static final WireMockConfiguration OPTIONS = options();
+    private final Wiremock mockedServer = mock(Wiremock.class);
+    private final WiremockFactory factory = new WiremockFactory();
+
+    @BeforeEach
+    public void setup() {
+        when(mockedServer.factory()).thenReturn((Class) StubClass.class);
+        when(mockedServer.customizer()).thenReturn((Class) StubClass.class);
+    }
+
+    @Test
+    public void createServer() {
+        WireMockServer srv1 = factory.createServer(mockedServer);
+        WireMockServer srv2 = factory.createServer(mockedServer);
+        assertNotNull(srv1);
+        assertNotNull(srv2);
+        assertSame(OPTIONS, srv1.getOptions());
+        assertSame(OPTIONS, srv2.getOptions());
+        assertNotSame(srv1, srv2);
+    }
+
+    @Test
+    public void configFactoryCouldNotBeInstantiated() {
+        when(mockedServer.factory()).thenReturn((Class) PrivateClassNotAllowed.class);
+
+        try {
+            factory.createServer(mockedServer);
+            fail("Exception expected here");
+        } catch (final ParameterResolutionException expected) {
+            assertEquals("Can't createServer config with given factory class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void createContextBuilder() {
+        CustomizationContextBuilder builder1 = factory.createContextBuilder();
+        CustomizationContextBuilder builder2 = factory.createContextBuilder();
+        assertNotNull(builder1);
+        assertNotNull(builder2);
+        assertNotSame(builder1, builder2);
+    }
+
+    @Test
+    public void createCustomizer() {
+        WiremockCustomizer customizer1 = factory.createCustomizer(mockedServer);
+        WiremockCustomizer customizer2 = factory.createCustomizer(mockedServer);
+        assertNotNull(customizer1);
+        assertNotNull(customizer2);
+        assertNotSame(customizer1, customizer2);
+    }
+
+    @Test
+    public void customizerCouldNotBeInstantiated() {
+        when(mockedServer.customizer()).thenReturn((Class) PrivateClassNotAllowed.class);
+
+        try {
+            factory.createCustomizer(mockedServer);
+            fail("Exception expected here");
+        } catch (final ParameterResolutionException expected) {
+            assertEquals("Can't customize server with given customizer class ru.lanwen.wiremock.ext.WiremockFactoryTest$PrivateClassNotAllowed", expected.getMessage());
+        }
+    }
+}

--- a/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static ru.lanwen.wiremock.testlib.TicketEndpoint.X_TEST_METHOD_NAME_HEADER;
 import static ru.lanwen.wiremock.testlib.TicketEndpoint.X_TICKET_ID_HEADER;
 
 /**
@@ -32,6 +33,10 @@ class WiremockResolverTest {
         TicketApi api = TicketApi.connect(uri);
 
         Response response = api.create(new Eticket());
+        Collection<String> testMethodNames = response.headers().get(X_TEST_METHOD_NAME_HEADER);
+        assertThat("testMethodNames", testMethodNames, hasSize(1));
+        assertThat("shouldCreateTicket", is(testMethodNames.iterator().next()));
+
         Collection<String> ids = response.headers().get(X_TICKET_ID_HEADER);
 
         assertThat("ids", ids, hasSize(1));

--- a/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverUnitTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverUnitTest.java
@@ -1,0 +1,135 @@
+package ru.lanwen.wiremock.ext;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.mockito.InOrder;
+import ru.lanwen.wiremock.config.CustomizationContext;
+import ru.lanwen.wiremock.config.CustomizationContext.CustomizationContextBuilder;
+import ru.lanwen.wiremock.config.WiremockCustomizer;
+import ru.lanwen.wiremock.ext.WiremockResolver.Wiremock;
+
+import java.lang.reflect.Parameter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static ru.lanwen.wiremock.ext.WiremockResolver.WIREMOCK_PORT;
+
+/**
+ * @author SourcePond (Roland Hauser)
+ */
+public class WiremockResolverUnitTest {
+    private static final int EXPECTED_PORT = 8088;
+    private WiremockFactory wiremockFactory = mock(WiremockFactory.class);
+    private WireMockServer server = mock(WireMockServer.class);
+    private CustomizationContextBuilder customizationContextBuilder = mock(CustomizationContextBuilder.class);
+    private CustomizationContext customizationContext = mock(CustomizationContext.class);
+    private WiremockCustomizer customizer = mock(WiremockCustomizer.class);
+    private ExtensionContext extensionContext = mock(ExtensionContext.class);
+    private ParameterContext parameterContext = mock(ParameterContext.class);
+    private Namespace namespace = create(WiremockResolver.class);
+    private Store store = mock(Store.class);
+    private WiremockResolver resolver = new WiremockResolver(wiremockFactory);
+    private Wiremock mockedServer;
+    private Parameter serverParameter;
+
+    private void supportedMethod(@Wiremock WireMockServer server) {
+
+    }
+
+    private void unsupportedMethod(WireMockServer server) {
+
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        serverParameter = getClass().getDeclaredMethod("supportedMethod", WireMockServer.class).getParameters()[0];
+        mockedServer = serverParameter.getAnnotation(Wiremock.class);
+        when(wiremockFactory.createServer(mockedServer)).thenReturn(server);
+        when(wiremockFactory.createContextBuilder()).thenReturn(customizationContextBuilder);
+        when(wiremockFactory.createCustomizer(mockedServer)).thenReturn(customizer);
+        when(customizationContextBuilder.extensionContext(extensionContext)).thenReturn(customizationContextBuilder);
+        when(customizationContextBuilder.parameterContext(parameterContext)).thenReturn(customizationContextBuilder);
+        when(customizationContextBuilder.build()).thenReturn(customizationContext);
+        when(server.isRunning()).thenReturn(true);
+        when(server.port()).thenReturn(EXPECTED_PORT);
+        when(parameterContext.getParameter()).thenReturn(serverParameter);
+        when(extensionContext.getStore(namespace)).thenReturn(store);
+    }
+
+    @Test
+    public void verifyDefaultConstructor() {
+        // Make code coverage happy
+        new WiremockResolver();
+    }
+
+    @Test
+    public void afterEachServerIsNull() throws Exception {
+        resolver.afterEach(extensionContext);
+        verifyZeroInteractions(extensionContext);
+    }
+
+    @Test
+    public void afterEachServerIsNotRunning() throws Exception {
+        resolver.resolveParameter(parameterContext, extensionContext);
+        when(server.isRunning()).thenReturn(false);
+        resolver.afterEach(extensionContext);
+        verify(extensionContext).getStore(namespace);
+        verifyNoMoreInteractions(extensionContext);
+    }
+
+    @Test
+    public void afterEach() throws Exception {
+        resolver.resolveParameter(parameterContext, extensionContext);
+        resolver.afterEach(extensionContext);
+        final InOrder order = inOrder(server);
+        order.verify(server).resetRequests();
+        order.verify(server).resetToDefaultMappings();
+        order.verify(server).stop();
+    }
+
+    @Test
+    public void supportsParameter() throws Exception {
+        assertTrue(resolver.supportsParameter(parameterContext, extensionContext));
+        serverParameter = getClass().getDeclaredMethod("unsupportedMethod", WireMockServer.class).getParameters()[0];
+        when(parameterContext.getParameter()).thenReturn(serverParameter);
+        assertFalse(resolver.supportsParameter(parameterContext, extensionContext));
+    }
+
+    @Test
+    public void resolveParameterFailed() throws Exception {
+        final Exception expected = new Exception();
+        doThrow(expected).when(customizer).customize(server, customizationContext);
+        try {
+            resolver.resolveParameter(parameterContext, extensionContext);
+            fail("Exception expected");
+        } catch (final ParameterResolutionException e) {
+            assertSame(expected, e.getCause());
+        }
+    }
+
+    @Test
+    public void resolveParameter() throws Exception {
+        assertSame(server, resolver.resolveParameter(parameterContext, extensionContext));
+        final InOrder order = inOrder(server, customizer, extensionContext, store);
+        order.verify(server).start();
+        order.verify(customizer).customize(server, customizationContext);
+        order.verify(extensionContext).getStore(namespace);
+        order.verify(store).put(WIREMOCK_PORT, EXPECTED_PORT);
+    }
+}

--- a/src/test/java/ru/lanwen/wiremock/testlib/TicketEndpoint.java
+++ b/src/test/java/ru/lanwen/wiremock/testlib/TicketEndpoint.java
@@ -1,6 +1,8 @@
 package ru.lanwen.wiremock.testlib;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import ru.lanwen.wiremock.config.CustomizationContext;
 import ru.lanwen.wiremock.config.WiremockCustomizer;
 
 import java.util.UUID;
@@ -17,10 +19,13 @@ import static java.lang.String.format;
 public class TicketEndpoint implements WiremockCustomizer {
 
     public static final String X_TICKET_ID_HEADER = "X-Ticket-ID";
+    public static final String X_TEST_METHOD_NAME_HEADER = "X-TestMethodName";
 
     @Override
-    public void customize(WireMockServer server) {
+    public void customize(WireMockServer server, CustomizationContext customizationContext) {
+        ExtensionContext context = customizationContext.getExtensionContext();
         String uuid = UUID.randomUUID().toString();
+        String testMethodName = context.getTestMethod().get().getName();
 
         server.stubFor(
                 post(urlPathEqualTo("/ticket"))
@@ -30,6 +35,7 @@ public class TicketEndpoint implements WiremockCustomizer {
                                         "Location",
                                         format("http://localhost:%s/ticket/%s", server.port(), uuid)
                                 )
+                                .withHeader(X_TEST_METHOD_NAME_HEADER, testMethodName)
                                 .withHeader(X_TICKET_ID_HEADER, uuid))
         );
 
@@ -38,6 +44,7 @@ public class TicketEndpoint implements WiremockCustomizer {
                         .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader("Content-Type", "application/json")
+                                .withHeader(X_TEST_METHOD_NAME_HEADER, testMethodName)
                                 .withHeader(X_TICKET_ID_HEADER, uuid)
                                 .withBody(format("{ \"uuid\": \"%s\" }", uuid))
                         )


### PR DESCRIPTION
- Introduced a parameter class CustomizationContext which additionally provides ExtensionContext and ParameterContext objects. This allows to implement more sophisticated setup logic based on the execution context.
- Added WiremockCustomizer::customize(WireMockServer server, CustomizationContext ctx) as default method to keep backward compatibility.
- Made WiremockCustomizer::customize(WireMockServer server) also a default method. This is to make sure, that only the necessary "customize" method needs be implemented on a WiremockCustomizer implementation (see TicketEndpoint).
- Allow to throw an exception from WiremockCustomizer::customize
- Added Unit-Tests
- Updated dependencies and plugin versions where possible
- Bumped version to 2.0.0-SNAPSHOT because the interface change