### PR TITLE
@Wiremock => stopserver 

### DIFF
--- a/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizer.java
+++ b/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizer.java
@@ -12,11 +12,11 @@ import ru.lanwen.wiremock.ext.WiremockResolver;
  */
 public interface WiremockCustomizer {
 
-    default void customize(WireMockServer server) throws Exception {
+    default void customize(WireMockServer server) throws WiremockCustomizerException {
         // noop
     }
 
-    default void customize(WireMockServer server, CustomizationContext ctx) throws Exception {
+    default void customize(WireMockServer server, CustomizationContext ctx) throws WiremockCustomizerException {
         customize(server);
     }
 

--- a/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizerException.java
+++ b/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizerException.java
@@ -7,6 +7,6 @@ package ru.lanwen.wiremock.config;
  * @author Vincent Palau
  * @see WiremockCustomizer
  */
-public class WiremockCustomizerException extends RuntimeException {
+public class WiremockCustomizerException extends Exception {
 
 }

--- a/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizerException.java
+++ b/src/main/java/ru/lanwen/wiremock/config/WiremockCustomizerException.java
@@ -1,0 +1,12 @@
+package ru.lanwen.wiremock.config;
+
+/**
+ * {@code WiremockCustomizerException} is the superclass of those
+ * exceptions that can be thrown during the normal customizing operation.
+ *
+ * @author Vincent Palau
+ * @see WiremockCustomizer
+ */
+public class WiremockCustomizerException extends RuntimeException {
+
+}

--- a/src/main/java/ru/lanwen/wiremock/config/WiremockShutdownStrategy.java
+++ b/src/main/java/ru/lanwen/wiremock/config/WiremockShutdownStrategy.java
@@ -1,0 +1,22 @@
+package ru.lanwen.wiremock.config;
+
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+/**
+ * Defines whenever to shutdown the server: AFTER_EACH or AFTER_ALL test execution.
+ *
+ * @author Vincent Palau
+ * @see WiremockResolver.Wiremock
+ */
+public enum WiremockShutdownStrategy {
+
+    /**
+     * Should shutdown the server after each test method has been invoked.
+     */
+    AFTER_EACH,
+
+    /**
+     * Should shutdown the server after all tests have been invoked.
+     */
+    AFTER_ALL
+}

--- a/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
+++ b/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
@@ -2,12 +2,8 @@ package ru.lanwen.wiremock.ext;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
 import ru.lanwen.wiremock.config.CustomizationContext;
 import ru.lanwen.wiremock.config.WiremockConfigFactory;
 import ru.lanwen.wiremock.config.WiremockCustomizer;
@@ -20,16 +16,19 @@ import java.lang.annotation.Target;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 import static ru.lanwen.wiremock.ext.Validate.validState;
+import static ru.lanwen.wiremock.ext.WiremockResolver.Wiremock.StopServer.AFTER_ALL;
+import static ru.lanwen.wiremock.ext.WiremockResolver.Wiremock.StopServer.AFTER_EACH;
 
 /**
  * @author lanwen (Merkushev Kirill)
  */
 @Slf4j
-public class WiremockResolver implements ParameterResolver, AfterEachCallback {
+public class WiremockResolver implements ParameterResolver, AfterEachCallback, AfterAllCallback {
     static final String WIREMOCK_PORT = "wiremock.port";
 
     private final WiremockFactory wiremockFactory;
-    private WireMockServer server;
+    protected WireMockServer server;
+    protected Wiremock.StopServer stopServer;
 
     public WiremockResolver() {
         this(new WiremockFactory());
@@ -40,15 +39,26 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback {
     }
 
     @Override
-    public void afterEach(ExtensionContext testExtensionContext) throws Exception {
-        if (server == null || !server.isRunning()) {
-            return;
+    public void afterEach(ExtensionContext testExtensionContext) {
+        if (AFTER_EACH == stopServer) {
+            stopServerWhenIsRunning();
         }
+    }
 
-        server.resetRequests();
-        server.resetToDefaultMappings();
-        log.info("Stopping wiremock server on localhost:{}", server.port());
-        server.stop();
+    @Override
+    public void afterAll(ExtensionContext context) {
+        if (AFTER_ALL == stopServer) {
+            stopServerWhenIsRunning();
+        }
+    }
+
+    private void stopServerWhenIsRunning() {
+        if (server != null && server.isRunning()) {
+            server.resetRequests();
+            server.resetToDefaultMappings();
+            log.info("Stopping Wiremock server on localhost:{}", server.port());
+            server.stop();
+        }
     }
 
     @Override
@@ -65,13 +75,15 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback {
 
         Wiremock mockedServer = parameterContext.getParameter().getAnnotation(Wiremock.class);
 
+        stopServer = mockedServer.stopserver();
+
         server = wiremockFactory.createServer(mockedServer);
         server.start();
 
-        CustomizationContext customizationContext = wiremockFactory.createContextBuilder().
-                parameterContext(parameterContext).
-                extensionContext(extensionContext).
-                build();
+        CustomizationContext customizationContext = wiremockFactory.createContextBuilder()
+                .parameterContext(parameterContext)
+                .extensionContext(extensionContext)
+                .build();
 
         try {
             wiremockFactory.createCustomizer(mockedServer).customize(server, customizationContext);
@@ -85,12 +97,12 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback {
         ExtensionContext.Store store = extensionContext.getStore(Namespace.create(WiremockResolver.class));
         store.put(WIREMOCK_PORT, server.port());
 
-        log.info("Started wiremock server on localhost:{}", server.port());
+        log.info("Started Wiremock server on localhost:{}", server.port());
         return server;
     }
 
     /**
-     * Enables injection of wiremock server to test.
+     * Enables injection of Wiremock server to test.
      * Helps to configure instance with {@link #factory} and {@link #customizer} methods
      */
     @Target({ElementType.PARAMETER})
@@ -105,5 +117,25 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback {
          * @return class which defines on how to customize server after start
          */
         Class<? extends WiremockCustomizer> customizer() default WiremockCustomizer.NoopWiremockCustomizer.class;
+
+        /**
+         * @return whenever to stop the server: AFTER_EACH or AFTER_ALL
+         */
+        StopServer stopserver() default AFTER_EACH;
+
+        /**
+         * Defines whenever to stop the server: AFTER_EACH or AFTER_ALL
+         */
+        enum StopServer {
+            /**
+             * Should stop the server after each test method has been invoked.
+             */
+            AFTER_EACH,
+
+            /**
+             * Should stop the server after all tests have been invoked.
+             */
+            AFTER_ALL
+        }
     }
 }

--- a/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
+++ b/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
@@ -2,8 +2,14 @@ package ru.lanwen.wiremock.ext;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
 import ru.lanwen.wiremock.config.CustomizationContext;
 import ru.lanwen.wiremock.config.WiremockConfigFactory;
 import ru.lanwen.wiremock.config.WiremockCustomizer;

--- a/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
+++ b/src/main/java/ru/lanwen/wiremock/ext/WiremockResolver.java
@@ -48,24 +48,26 @@ public class WiremockResolver implements ParameterResolver, AfterEachCallback, A
     @Override
     public void afterEach(ExtensionContext testExtensionContext) {
         if (AFTER_EACH == shutdownStrategy) {
-            stopServerWhenIsRunning();
+            shutdownServerWhenIsRunning();
         }
     }
 
     @Override
     public void afterAll(ExtensionContext context) {
         if (AFTER_ALL == shutdownStrategy) {
-            stopServerWhenIsRunning();
+            shutdownServerWhenIsRunning();
         }
     }
 
-    private void stopServerWhenIsRunning() {
-        if (server != null && server.isRunning()) {
-            server.resetRequests();
-            server.resetToDefaultMappings();
-            log.info("Stopping Wiremock server on localhost:{}", server.port());
-            server.stop();
+    private void shutdownServerWhenIsRunning() {
+        if (server == null || !server.isRunning()) {
+            return;
         }
+
+        server.resetRequests();
+        server.resetToDefaultMappings();
+        log.info("Stopping Wiremock server on localhost:{}", server.port());
+        server.stop();
     }
 
     @Override

--- a/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverUnitTest.java
+++ b/src/test/java/ru/lanwen/wiremock/ext/WiremockResolverUnitTest.java
@@ -20,8 +20,8 @@ import java.lang.reflect.Parameter;
 import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
-import static ru.lanwen.wiremock.ext.WiremockResolver.Wiremock.StopServer.AFTER_ALL;
-import static ru.lanwen.wiremock.ext.WiremockResolver.Wiremock.StopServer.AFTER_EACH;
+import static ru.lanwen.wiremock.config.WiremockShutdownStrategy.AFTER_ALL;
+import static ru.lanwen.wiremock.config.WiremockShutdownStrategy.AFTER_EACH;
 
 /**
  * @author SourcePond (Roland Hauser)
@@ -79,7 +79,7 @@ public class WiremockResolverUnitTest {
 
     @Test
     public void afterEachServerIsNull() {
-        resolver.stopServer = AFTER_EACH;
+        resolver.shutdownStrategy = AFTER_EACH;
         resolver.afterEach(extensionContext);
         verifyZeroInteractions(extensionContext);
     }
@@ -88,9 +88,9 @@ public class WiremockResolverUnitTest {
     public void afterEachServerWhenNotNullButNotRunning() {
         when(server.isRunning()).thenReturn(false);
 
-        // set server and stopServer directly avoiding to call method resolver.resolveParameter()
+        // set server and shutdownStrategy directly avoiding to call method resolver.resolveParameter()
         resolver.server = server;
-        resolver.stopServer = AFTER_EACH;
+        resolver.shutdownStrategy = AFTER_EACH;
 
         resolver.afterEach(extensionContext);
         verifyZeroInteractions(extensionContext);
@@ -99,7 +99,7 @@ public class WiremockResolverUnitTest {
 
     @Test
     public void afterAllServerIsNull() {
-        resolver.stopServer = AFTER_ALL;
+        resolver.shutdownStrategy = AFTER_ALL;
         resolver.afterAll(extensionContext);
         verifyZeroInteractions(extensionContext);
     }
@@ -118,9 +118,9 @@ public class WiremockResolverUnitTest {
     public void afterAllServerWhenNotNullButNotRunning() {
         when(server.isRunning()).thenReturn(false);
 
-        // set server and stopServer directly avoiding to call method resolver.resolveParameter()
+        // set server and shutdownStrategy directly avoiding to call method resolver.resolveParameter()
         resolver.server = server;
-        resolver.stopServer = AFTER_ALL;
+        resolver.shutdownStrategy = AFTER_ALL;
 
         resolver.afterAll(extensionContext);
         verifyZeroInteractions(extensionContext);


### PR DESCRIPTION
 - New param on @Wiremock => stopserver with default value: AFTER_EACH to maintain compatibility with previous versions

 - WiremockCustomizer have now a Custom RuntimeException --> WiremockCustomizerException
 - WiremockResolver implements AfterEachCallback + AfterAllCallback like described at: #11 
 - Required Tests implemented with coverage.